### PR TITLE
Fix wrong topic remapping

### DIFF
--- a/LeGO-LOAM/launch/run.launch.py
+++ b/LeGO-LOAM/launch/run.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
     executable='lego_loam_sr',
     output='screen',
     parameters=[config_file],
-    remappings=[('/lidar_points', '/velodyne_points')],
+    remappings=[('/rslidar_points', '/velodyne_points')],
   )
 
   # Rviz


### PR DESCRIPTION
I think we have to use this remapping like that since in seems like the `/lidar_points` topic name is renamed internally. 